### PR TITLE
Optimize `eval()` and other refactors

### DIFF
--- a/include/Peanut/impl/binary_expr/matrix_div_scalar.h
+++ b/include/Peanut/impl/binary_expr/matrix_div_scalar.h
@@ -58,8 +58,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = static_cast<Type>(x(i, j)) / static_cast<Float>(y);
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/binary_expr/matrix_emult.h
+++ b/include/Peanut/impl/binary_expr/matrix_emult.h
@@ -53,8 +53,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E1::Row;
         static constexpr Index Col = E1::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(i, j) * y(i, j);
+                }
+            }
         }
 
         const E1 &x;

--- a/include/Peanut/impl/binary_expr/matrix_mult.h
+++ b/include/Peanut/impl/binary_expr/matrix_mult.h
@@ -44,7 +44,10 @@ namespace Peanut::Impl {
         requires(E1::Col == E2::Row)
     struct MatrixMult : public MatrixExpr<MatrixMult<E1, E2>> {
         using Type = typename E1::Type;
-        MatrixMult(const E1 &_x, const E2 &_y) : x_eval{_x}, y_eval{_y} {}
+        MatrixMult(const E1 &_x, const E2 &_y) {
+            _x.eval(x_eval);
+            _y.eval(y_eval);
+        }
 
         // Static polymorphism implementation of MatrixExpr
         INLINE auto operator()(Index r, Index c) const {
@@ -58,13 +61,20 @@ namespace Peanut::Impl {
         static constexpr Index Row = E1::Row;
         static constexpr Index Col = E2::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x_eval(i, 0) * y_eval(0, j);
+                    for (Index k = 1; k < E1::Col; k++) {
+                        _result(i, j) += x_eval(i, k) * y_eval(k, j);
+                    }
+                }
+            }
         }
 
         // Specify member type as Matrix for evaluation
-        const Matrix<Type, E1::Row, E1::Col> x_eval;
-        const Matrix<Type, E2::Row, E2::Col> y_eval;
+        Matrix<Type, E1::Row, E1::Col> x_eval;
+        Matrix<Type, E2::Row, E2::Col> y_eval;
     };
 
 }

--- a/include/Peanut/impl/binary_expr/matrix_mult_scalar.h
+++ b/include/Peanut/impl/binary_expr/matrix_mult_scalar.h
@@ -54,8 +54,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = static_cast<Type>(x(i, j)) * static_cast<Type>(y);
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/binary_expr/matrix_subtract.h
+++ b/include/Peanut/impl/binary_expr/matrix_subtract.h
@@ -52,8 +52,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E1::Row;
         static constexpr Index Col = E1::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(i, j) - y(i, j);
+                }
+            }
         }
 
         const E1 &x;

--- a/include/Peanut/impl/binary_expr/matrix_sum.h
+++ b/include/Peanut/impl/binary_expr/matrix_sum.h
@@ -52,8 +52,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E1::Row;
         static constexpr Index Col = E1::Col;
 
-        INLINE auto eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(i, j) + y(i, j);
+                }
+            }
         }
 
         const E1 &x;

--- a/include/Peanut/impl/matrix.h
+++ b/include/Peanut/impl/matrix.h
@@ -300,8 +300,12 @@ namespace Peanut {
          *        method even though it is not a method of `MatrixExpr`.
          * @return Evaluated matrix
          */
-        INLINE Matrix<Type, Row, Col> eval() const{
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const{
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = m_data[i*C+j];
+                }
+            }
         }
 
         // =============== Features for vector usage begins ================
@@ -461,8 +465,11 @@ namespace Peanut {
             }
             else{
                 T ret = static_cast<T>(0);
+
                 for_<C>([&] (auto c) {
-                    ret += (c.value % 2 ? -1 : 1) * m_data[c.value] * SubMat<0, c.value>(*this).eval().det();
+                    Matrix<T, R-1, C-1> submat;
+                    SubMat<0, c.value>(*this).eval(submat);
+                    ret += (c.value % 2 ? -1 : 1) * m_data[c.value] * submat.det();
                 });
                 return ret;
             }

--- a/include/Peanut/impl/matrix.h
+++ b/include/Peanut/impl/matrix.h
@@ -298,7 +298,7 @@ namespace Peanut {
          * @brief Evaluation expressions and return as a `Matrix` instance.
          *        Note that every matrix expression classes must implement this
          *        method even though it is not a method of `MatrixExpr`.
-         * @return Evaluated matrix
+         * @param Evaluated matrix (reference output)
          */
         void eval(Matrix<Type, Row, Col> &_result) const{
             for (int i=0;i<Row;i++) {

--- a/include/Peanut/impl/unary_expr/adjugate.h
+++ b/include/Peanut/impl/unary_expr/adjugate.h
@@ -48,10 +48,15 @@ namespace Peanut::Impl {
                 for_<Col>([&](auto c) {
                     constexpr Index rv = r.value;
                     constexpr Index cv = c.value;
-                    const Type e = SubMat<rv, cv>(_x).eval().det();
+
+                    Matrix<Type, Row-1, Col-1> submat;
+                    SubMat<rv, cv>(_x).eval(submat);
+                    const Type e = submat.det();
+
                     if constexpr ((rv + cv) % 2 == 0) {
                         mat_eval(cv, rv) = e;
-                    } else {
+                    }
+                    else {
                         mat_eval(cv, rv) = -e;
                     }
                 });
@@ -66,8 +71,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return mat_eval;
+        INLINE void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = mat_eval(i, j);
+                }
+            }
         }
 
         Matrix<Type, Row, Col> mat_eval;

--- a/include/Peanut/impl/unary_expr/block.h
+++ b/include/Peanut/impl/unary_expr/block.h
@@ -55,8 +55,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = row_size;
         static constexpr Index Col = col_size;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(row_start + i, col_start + j);
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/unary_expr/cast.h
+++ b/include/Peanut/impl/unary_expr/cast.h
@@ -51,8 +51,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = static_cast<T>(x(i, j));
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/unary_expr/cofactor.h
+++ b/include/Peanut/impl/unary_expr/cofactor.h
@@ -48,7 +48,9 @@ namespace Peanut::Impl {
                 for_<Col>([&](auto c) {
                     constexpr Index rv = r.value;
                     constexpr Index cv = c.value;
-                    const Type e = SubMat<rv, cv>(_x).eval().det();
+                    Matrix<Type, Row-1, Col-1> submat;
+                    SubMat<rv, cv>(_x).eval(submat);
+                    const Type e = submat.det();
                     if constexpr ((rv + cv) % 2 == 0) {
                         mat_eval(rv, cv) = e;
                     } else {
@@ -66,8 +68,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return mat_eval;
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = mat_eval(i, j);
+                }
+            }
         }
 
         Peanut::Matrix<Type, Row, Col> mat_eval;

--- a/include/Peanut/impl/unary_expr/inverse.h
+++ b/include/Peanut/impl/unary_expr/inverse.h
@@ -59,8 +59,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = invdet * cofactor_eval(j, i);
+                }
+            }
         }
 
         const E &x;// used for optimization

--- a/include/Peanut/impl/unary_expr/minor.h
+++ b/include/Peanut/impl/unary_expr/minor.h
@@ -45,7 +45,9 @@ namespace Peanut::Impl {
         MatrixMinor(const E &_x) {
             for_<Row>([&](auto r) {
                 for_<Col>([&](auto c) {
-                    mat_eval(r.value, c.value) = SubMat<r.value, c.value>(_x).eval().det();
+                    Matrix<Type, Row-1, Col-1> submat;
+                    SubMat<r.value, c.value>(_x).eval(submat);
+                    mat_eval(r.value, c.value) = submat.det();
                 });
             });
         }
@@ -58,8 +60,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return mat_eval;
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = mat_eval(i, j);
+                }
+            }
         }
 
         Matrix<Type, Row, Col> mat_eval;

--- a/include/Peanut/impl/unary_expr/negation.h
+++ b/include/Peanut/impl/unary_expr/negation.h
@@ -51,8 +51,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row;
         static constexpr Index Col = E::Col;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = -x(i, j);
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/unary_expr/submatrix.h
+++ b/include/Peanut/impl/unary_expr/submatrix.h
@@ -54,8 +54,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Row - 1;
         static constexpr Index Col = E::Col - 1;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(i < row_ex ? i : i + 1, j < col_ex ? j : j + 1);
+                }
+            }
         }
 
         const E &x;

--- a/include/Peanut/impl/unary_expr/transpose.h
+++ b/include/Peanut/impl/unary_expr/transpose.h
@@ -51,8 +51,12 @@ namespace Peanut::Impl {
         static constexpr Index Row = E::Col;
         static constexpr Index Col = E::Row;
 
-        INLINE Matrix<Type, Row, Col> eval() const {
-            return Matrix<Type, Row, Col>(*this);
+        void eval(Matrix<Type, Row, Col> &_result) const {
+            for (int i=0;i<Row;i++) {
+                for (int j=0;j<Col;j++) {
+                    _result(i,j) = x(j, i);
+                }
+            }
         }
 
         const E &x;

--- a/test/test_matrix_unary_op.cpp
+++ b/test/test_matrix_unary_op.cpp
@@ -37,7 +37,8 @@ TEST_CASE("Test unary operation : T"){
                                   4,5,6};
 
     SECTION("Validation"){
-        auto tmat = T(mat).eval();
+        Peanut::Matrix<int, 3, 2> tmat;
+        T(mat).eval(tmat);
 
         CHECK(tmat(0, 0) == 1);
         CHECK(tmat(0, 1) == 4);
@@ -62,7 +63,8 @@ TEST_CASE("Test unary operation : Block"){
                                   13,14,15,16};
 
     SECTION("Validation"){
-        auto b1 = Peanut::Block<0,1,3,2>(mat).eval();
+        Peanut::Matrix<int, 3, 2> b1;
+        Peanut::Block<0,1,3,2>(mat).eval(b1);
         CHECK(b1(0, 0) == 2);
         CHECK(b1(0, 1) == 3);
         CHECK(b1(1, 0) == 6);
@@ -70,14 +72,16 @@ TEST_CASE("Test unary operation : Block"){
         CHECK(b1(2, 0) == 10);
         CHECK(b1(2, 1) == 11);
 
-        auto b2 = Peanut::Block<0,0,4,4>(mat).eval();
-        for(int i=0;i<4;i++){
+        Peanut::Matrix<int, 4, 4> b2;
+        Peanut::Block<0, 0, 4, 4>(mat).eval(b2);
+        for (int i=0;i<4;i++){
             for(int j=0;j<4;j++){
                 CHECK(mat(i,j) == b2(i,j));
             }
         }
 
-        auto b3 = Peanut::Block<3,3,1,1>(mat).eval();
+        Peanut::Matrix<int, 1, 1> b3;
+        Peanut::Block<3,3,1,1>(mat).eval(b3);
         CHECK(b3(0,0) == 16);
     }
 }
@@ -107,7 +111,8 @@ TEST_CASE("Test unary operation : SubMat"){
                                   13,14,15,16};
 
     SECTION("Validation"){
-        auto d1 = Peanut::SubMat<2, 1>(mat).eval();
+        Peanut::Matrix<int, 3, 3> d1;
+        Peanut::SubMat<2, 1>(mat).eval(d1);
 
         CHECK(d1(0, 0) == 1);
         CHECK(d1(0, 1) == 3);
@@ -119,7 +124,8 @@ TEST_CASE("Test unary operation : SubMat"){
         CHECK(d1(2, 1) == 15);
         CHECK(d1(2, 2) == 16);
 
-        auto d2 = Peanut::SubMat<0, 0>(mat).eval();
+        Peanut::Matrix<int, 3, 3> d2;
+        Peanut::SubMat<0, 0>(mat).eval(d2);
         CHECK(d2(0, 0) == 6);
         CHECK(d2(0, 1) == 7);
         CHECK(d2(0, 2) == 8);
@@ -130,7 +136,8 @@ TEST_CASE("Test unary operation : SubMat"){
         CHECK(d2(2, 1) == 15);
         CHECK(d2(2, 2) == 16);
 
-        auto d3 = Peanut::SubMat<3, 3>(mat).eval();
+        Peanut::Matrix<int, 3, 3> d3;
+        Peanut::SubMat<3, 3>(mat).eval(d3);
         CHECK(d3(0, 0) == 1);
         CHECK(d3(0, 1) == 2);
         CHECK(d3(0, 2) == 3);
@@ -149,7 +156,8 @@ TEST_CASE("Test unary operation : Cast"){
                                     3.3f, 4.4f};
 
     SECTION("Validation"){
-        auto intmat = Peanut::Cast<int>(mat).eval();
+        Peanut::Matrix<int, 2, 2> intmat;
+        Peanut::Cast<int>(mat).eval(intmat);
 
         CHECK(intmat(0, 0) != Catch::Approx(1.1f));
         CHECK(intmat(0, 1) != Catch::Approx(2.2f));
@@ -210,7 +218,8 @@ TEST_CASE("Test unary operation : Combination of unary operations (1)"){
         // 3.5 2.5 3.4
         // 4.2 4.1 5.2
 
-        auto result1 = T(Block<0, 0, 3, 3>(SubMat<1, 2>(T(Block<0, 0, 4, 4>(T(test))))));
+        Peanut::Matrix<float, 3, 3> result1;
+        T(Block<0, 0, 3, 3>(SubMat<1, 2>(T(Block<0, 0, 4, 4>(T(test)))))).eval(result1);
         CHECK(result1(0, 0) == Catch::Approx(1.2f));
         CHECK(result1(0, 1) == Catch::Approx(4.1f));
         CHECK(result1(0, 2) == Catch::Approx(2.1f));
@@ -221,7 +230,8 @@ TEST_CASE("Test unary operation : Combination of unary operations (1)"){
         CHECK(result1(2, 1) == Catch::Approx(4.1f));
         CHECK(result1(2, 2) == Catch::Approx(5.2f));
 
-        auto result2 = T(Block<0, 0, 3, 3>(SubMat<1, 2>(T(Block<0, 0, 4, 4>(T(test)))))).eval();
+        Peanut::Matrix<float, 3, 3> result2;
+        T(Block<0, 0, 3, 3>(SubMat<1, 2>(T(Block<0, 0, 4, 4>(T(test)))))).eval(result2);
         CHECK(result2(0, 0) == Catch::Approx(1.2f));
         CHECK(result2(0, 1) == Catch::Approx(4.1f));
         CHECK(result2(0, 2) == Catch::Approx(2.1f));
@@ -246,7 +256,8 @@ TEST_CASE("Test unary operation : Minor"){
                                      7.6f, 2.5f, 4.8f};
 
     SECTION("Validation"){
-        auto mmat = Peanut::Minor(mat).eval();
+        Peanut::Matrix<float, 5, 5> mmat;
+        Peanut::Minor(mat).eval(mmat);
 
         CHECK(mmat(0, 0) == Catch::Approx(-128.631f));
         CHECK(mmat(0, 1) == Catch::Approx(-928.599f));
@@ -323,7 +334,8 @@ TEST_CASE("Test unary operation : Minor"){
         CHECK(mmat(2, 1) == Catch::Approx(-1.26145e+06f));
         CHECK(mmat(2, 2) == Catch::Approx(-1.56683e+06f));
 
-        auto mmat2 = Minor(Minor(Minor(mat2))).eval();
+        Peanut::Matrix<float, 3, 3> mmat2;
+        Minor(Minor(Minor(mat2))).eval(mmat2);
         CHECK(mmat2(0, 0) == Catch::Approx(2.43166e+06f));
         CHECK(mmat2(0, 1) == Catch::Approx(1.88045e+06f));
         CHECK(mmat2(0, 2) == Catch::Approx(-2.87072e+06f));
@@ -370,7 +382,8 @@ TEST_CASE("Test unary operation : Minor"){
         CHECK(val(1, 0) == Catch::Approx(9.74f));
         CHECK(val(1, 1) == Catch::Approx(-2.4f));
 
-        auto val2 = T(Minor(SubMat<1, 1>(Minor(Block<0, 0, 3, 3>(mat))))).eval();
+        Peanut::Matrix<float, 2, 2> val2;
+        T(Minor(SubMat<1, 1>(Minor(Block<0, 0, 3, 3>(mat))))).eval(val2);
 
         CHECK(val2(0, 0) == Catch::Approx(-2.14f));
         CHECK(val2(0, 1) == Catch::Approx(0.25f));
@@ -392,7 +405,8 @@ TEST_CASE("Test unary operation : Cofactor"){
                                      7.6f, 2.5f, 4.8f};
 
     SECTION("Validation"){
-        auto mmat = Peanut::Cofactor(mat).eval();
+        Peanut::Matrix<float, 5, 5> mmat;
+        Peanut::Cofactor(mat).eval(mmat);
 
         CHECK(mmat(0, 0) == Catch::Approx(-128.631f));
         CHECK(mmat(0, 1) == Catch::Approx(928.599f));
@@ -469,7 +483,8 @@ TEST_CASE("Test unary operation : Cofactor"){
         CHECK(mmat(2, 1) == Catch::Approx(1.26145e+06f));
         CHECK(mmat(2, 2) == Catch::Approx(-1.56683e+06f));
 
-        auto mmat2 = Cofactor(Cofactor(Cofactor(mat2))).eval();
+        Peanut::Matrix<float, 3, 3> mmat2;
+        Cofactor(Cofactor(Cofactor(mat2))).eval(mmat2);
         CHECK(mmat2(0, 0) == Catch::Approx(2.43166e+06f));
         CHECK(mmat2(0, 1) == Catch::Approx(-1.88045e+06f));
         CHECK(mmat2(0, 2) == Catch::Approx(-2.87072e+06f));
@@ -513,7 +528,8 @@ TEST_CASE("Test unary operation : Cofactor"){
         CHECK(val(1, 0) == Catch::Approx(24.05f));
         CHECK(val(1, 1) == Catch::Approx(38.38f));
 
-        auto val2 = T(Cofactor(SubMat<1, 1>(Cofactor(mat2)))).eval();
+        Peanut::Matrix<float, 2, 2> val2;
+        T(Cofactor(SubMat<1, 1>(Cofactor(mat2)))).eval(val2);
 
         CHECK(val2(0, 0) == Catch::Approx(-24.73f));
         CHECK(val2(0, 1) == Catch::Approx(45.31f));
@@ -534,7 +550,8 @@ TEST_CASE("Test unary operation : Adjugate"){
                                      7.6f, 2.5f, 4.8f};
 
     SECTION("Validation"){
-        auto mmat = Peanut::Adjugate(mat).eval();
+        Peanut::Matrix<float, 5, 5> mmat;
+        Peanut::Adjugate(mat).eval(mmat);
         CHECK(mmat(0, 0) == Catch::Approx(-128.631f));
         CHECK(mmat(0, 1) == Catch::Approx(450.856f));
         CHECK(mmat(0, 2) == Catch::Approx(631.634f));
@@ -610,7 +627,8 @@ TEST_CASE("Test unary operation : Adjugate"){
         CHECK(mmat(2, 1) == Catch::Approx(2.3619646429876788e+6f));
         CHECK(mmat(2, 2) == Catch::Approx(-1.5668290134411296e+6f));
 
-        auto mmat2 = Adjugate(Adjugate(Adjugate(mat2))).eval();
+        Peanut::Matrix<float, 3, 3> mmat2;
+        Adjugate(Adjugate(Adjugate(mat2))).eval(mmat2);
         CHECK(mmat2(0, 0) == Catch::Approx(2.4316578057367792e+6f));
         CHECK(mmat2(0, 1) == Catch::Approx(-1.1207927718468895e+6f));
         CHECK(mmat2(0, 2) == Catch::Approx(-1.5237459673780494e+6f));
@@ -632,7 +650,8 @@ TEST_CASE("Test unary operation : Inverse"){
                                      1.5f, 3.1f, 7.6f, 2.3f, 1.7f};
 
     SECTION("Validation"){
-        auto inv1 = Peanut::Inverse(mat1).eval();
+        Peanut::Matrix<float, 5, 5> inv1;
+        Peanut::Inverse(mat1).eval(inv1);
         CHECK(inv1(0, 0) == Catch::Approx(-0.0449671f));
         CHECK(inv1(0, 1) == Catch::Approx(0.157612f));
         CHECK(inv1(0, 2) == Catch::Approx(0.220808f));


### PR DESCRIPTION
1. Fix `eval()` to set value to given reference parameter rather than return evaluated matrix to avoid unnecessary memory allocation.
2. Also fix each classes to implement their own `eval()` rather than use `Matrix(const MatrixExpr<E> &expr)` constructor.
3. Fix test 